### PR TITLE
Fix already processed fragments being recognised as new due to change of base fragments url

### DIFF
--- a/fc2_live_dl/hls.py
+++ b/fc2_live_dl/hls.py
@@ -39,6 +39,13 @@ class HLSDownloader:
                 if len(line) > 0 and not line[0] == "#"
             ]
 
+    @staticmethod
+    def _get_fragment_id(fragment_url):
+        """Take url and return filename part of it"""
+        if not fragment_url:
+            return fragment_url
+        return fragment_url.split('?')[0].split('/')[-1]
+
     async def _fill_queue(self):
         last_fragment_timestamp = time.time()
         last_fragment = None
@@ -46,12 +53,12 @@ class HLSDownloader:
         while True:
             try:
                 frags = await self._get_fragment_urls()
+                frags_numbers = [self._get_fragment_id(url) for url in frags]
 
-                new_idx = 0
                 try:
-                    new_idx = 1 + frags.index(last_fragment)
-                except:
-                    pass
+                    new_idx = 1 + frags_numbers.index(self._get_fragment_id(last_fragment))
+                except ValueError:
+                    new_idx = 0
 
                 n_new = len(frags) - new_idx
                 if n_new > 0:


### PR DESCRIPTION
Same fragments might get different urls on a different worker server on two consecutive updates of hls playlist. `HLSDownloader._fill_queue` relies on comparison of full fragment urls to pick new ones, so when this happens it will treat all urls from the current playlist chunk as new, which will cause about ten fragments to get downloaded for a second time, leading to about a ten seconds segment of the video being repeated twice in the recording.

Here is an example of two different urls pointing to fragment with the same number and seemingly the same content:
```
https://us-west-1-media-worker1036.live.fc2.com/a/stream/v3/24678502/52/data/73436.ts?time=1703265219&hash=67345c5328fe0ebb54e35c3c1614d340625c55f264ffc66248879583423d2e3a
https://us-west-1-media-worker1035.live.fc2.com/a/stream/v3/24678502/52/data/73436.ts?time=1703265219&hash=2354e75fddf69a76f6f5b8337b880fa992ae42a15e4ddb6f9d077760bee1a54d
```

This PR makes it that only filename part of the fragment url (`73436.ts` for the links above) is used for comparison, which fixes the issue.

Currently there is no warning issued when it happens, but it can still be detected by `[hls] Found 12 new fragments` line in output. Perhaps some dedicated debug message should be added?